### PR TITLE
Update ArrayWrapper size method

### DIFF
--- a/dsa-23au/java-dsa/arrays-links/src/main/java/dev/codewithfriends/ArrayWrapper.java
+++ b/dsa-23au/java-dsa/arrays-links/src/main/java/dev/codewithfriends/ArrayWrapper.java
@@ -24,7 +24,7 @@ public class ArrayWrapper<T> implements List {
     @Override
     // Returns the current size when called
     public int size() {
-        return maxSize;
+        return currentSize;
     }
 
     @Override


### PR DESCRIPTION
changed the value that is returned from "size" from maxSize to currentSize, since size can be changed and won't necessarily lways be the max size.