### PR TITLE
Updated PeriodicTable.md at Linked Lists insert/insertlast for HW4

### DIFF
--- a/dsa-23au/PeriodicTable.md
+++ b/dsa-23au/PeriodicTable.md
@@ -5,7 +5,7 @@
 | From size n, afterwards...  | size increases to n+1 || size stays the same at `n`   ||||| size stays the same at `n`         | size decreases to `n-1`      |
 |                     | insertAt(i,v) | insertLast(v) | size() | isEmpty() | searchFor(v) | min() | max()    | replaceAt(i,v) | removeAt(i) |
 | Arrays              | [O(?)](#arrays-insert-at)          |               |        |           |              |       |          |                |             |
-| Linked lists        |               |               |        |           |              |       |          |                |             |
+| Linked lists        | [O(1)](#Linked-lists-insert-at)              |  [O(1)](#Linked-lists-insert-at)             |        |           |              |       |          |                |             |
 | Stacks              | [O(1)](#stacks-insert-at)             |               |        |           |              |       |          |                |             |
 | Queues              |               |               |        |           |              |       |          |                |             |
 | Heaps               |               |               |        |           |              |       |          |                |             |


### PR DESCRIPTION
I added the linked list insert big O time. It is O(1) because linked list you just make a node and its head, you do not need to transverse through the whole list. This is also possible at the insert at last because you can have a tail pointer and just insert there. You do not need to iterate through the whole list.