### PR TITLE
webcrawler update week6 WIP

### DIFF
--- a/web-24wi/assignments/wshine/rust/web-crawler/src/main.rs
+++ b/web-24wi/assignments/wshine/rust/web-crawler/src/main.rs
@@ -1,4 +1,5 @@
-use reqwest;
+use reqwest::{Error, Response};
+use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::env;
 
@@ -48,22 +49,49 @@ fn find_term(line: &str, search_term: &str) -> Option<String> {
         None
     }
 }
+async fn validate_response(req: Result<Response, Error>) -> Result<Response, u16> {
+    let status: u16;
+    if req.is_ok() {
+        status = req.as_ref().unwrap().status().as_u16();
+    } else {
+        status = req.as_ref().err().unwrap().status().unwrap().as_u16();
+    }
 
-async fn crawl(url: &str, search_term: &str) -> Result<(Vec<String>, Vec<String>), reqwest::Error> {
-    let response = reqwest::get(url).await?;
+    match status {
+        200 => Ok(req.unwrap()),
+        _ => Err(status),
+    }
+}
+fn validate_starting_url(start_url: &str) -> String {
+    let slash_count = start_url
+        .chars()
+        .filter(|c| *c == '/')
+        .collect::<Vec<char>>()
+        .len();
 
-    // store errors in separte list
-    // problem I'm seeing is that alot of requests on this page will return 404
-    // but still display a page, I am able to replicate this in the browser as
-    // well. for Example https://en.wikipedia.org/wiki/Sankey_diagram/wiki/Help:Contents
-    // properly displays a web page but returns a 404 status code on the get request
-    // I think this is handled by using an early return with
-    // reqwest::get(url).await?
-    // and only proceeding if return from this function is Ok, otherwise add the 
-    // error to a vec<reqwest::Error>
-    
-    let status_code = response.status();
-    let body_text = response.text().await?;
+    match slash_count.cmp(&3) {
+        Ordering::Less => panic!(
+            "Exiting, url given is probably not a valid url. 
+Make sure to include a / at the end."
+        ),
+        Ordering::Greater => {
+            let base_url_end_index = start_url.match_indices("/").nth(2);
+            start_url
+                .split_at(base_url_end_index.unwrap().0)
+                .0
+                .to_string()
+        }
+        Ordering::Equal => {
+            if start_url.ends_with(r"/") {
+                start_url[0..start_url.len() - 1].to_string()
+            } else {
+                start_url.to_string()
+            }
+        }
+    }
+}
+async fn search(res: reqwest::Response, search_term: &str) -> (Vec<String>, Vec<String>) {
+    let body_text = res.text().await.expect("err getting text body");
     let mut next_links: Vec<String> = Vec::new();
     let mut matches: Vec<String> = Vec::new();
 
@@ -76,6 +104,7 @@ async fn crawl(url: &str, search_term: &str) -> Result<(Vec<String>, Vec<String>
         } else if line.contains("<img ") {
             let link = identify_svg(line);
             if link.is_some() {
+                println!("svg pushed: {:#?}", link.as_ref().unwrap());
                 next_links.push(link.unwrap());
             }
         } else {
@@ -86,7 +115,7 @@ async fn crawl(url: &str, search_term: &str) -> Result<(Vec<String>, Vec<String>
         }
     }
 
-    return Ok((matches, next_links));
+    return (matches, next_links);
 }
 
 #[derive(Debug)]
@@ -100,6 +129,11 @@ struct Options {
 struct SearchHits {
     url: String,
     hits: Vec<String>,
+}
+#[derive(Debug)]
+struct ReqError {
+    url: String,
+    status_code: u16,
 }
 
 #[tokio::main]
@@ -120,16 +154,21 @@ async fn main() {
             options = Options {
                 start_url: String::from("https://en.wikipedia.org/wiki/Sankey_diagram"),
                 search_term: String::from("albedo"),
-                max_depth: 3,
+                max_depth: 1,
             }
         }
     }
 
+    println!("{:#?}", options.start_url);
+    println!("{:#?}", options.search_term);
+    println!("{:#?}", options.max_depth);
+
+    let base_url = validate_starting_url(&options.start_url);
     let mut crawl_results: Vec<SearchHits> = Vec::new();
-    let mut crawl_errors: Vec<reqwest::Error> = Vec::new();
+    let mut crawl_errors: Vec<ReqError> = Vec::new();
     let mut crawl_next: Vec<String> = Vec::new();
     let mut visited: HashSet<String> = HashSet::new();
-    let mut depth = 1;
+    let mut depth = 0;
     crawl_next.push(options.start_url.to_string());
 
     while depth <= options.max_depth {
@@ -138,25 +177,27 @@ async fn main() {
             let hits: Vec<String>;
             let links: Vec<String>;
 
-            println!("{:#?}", url);
             if visited.contains(url) {
                 continue;
             }
-
-            let res = crawl(url, &options.search_term).await;
-            if res.is_ok() {
-                (hits, links) = res.unwrap();
-            } else {
-                eprint!("request Error: {}", res.as_ref().err().unwrap());
-                crawl_errors.push(res.err().unwrap());
-                continue;
-            }
+            println!("{:#?}", url);
+            let request = reqwest::get(url).await;
 
             visited.insert(url.to_string());
-
+            let result = validate_response(request).await;
+            match result {
+                Ok(req) => (hits, links) = search(req, &options.search_term).await,
+                Err(status_code) => {
+                    crawl_errors.push(ReqError {
+                        url: url.to_string(),
+                        status_code,
+                    });
+                    continue;
+                }
+            }
             for l in links {
                 if !visited.contains(&l) {
-                    next_links.push(format!("{}{}", &options.start_url.to_string(), l));
+                    next_links.push(format!("{}{}", &base_url, l));
                 }
             }
             if hits.len() > 0 {
@@ -175,7 +216,21 @@ async fn main() {
         println!("{}", depth);
         depth += 1;
     }
+
+    let svg_hits: Vec<&SearchHits> = crawl_results
+        .iter()
+        .filter(|h| h.url.ends_with(r".svg"))
+        .collect();
     println!("Number of urls visited: {}", visited.len());
     println!("Number of hits: {}", crawl_results.len());
     println!("Number of errors: {}", crawl_errors.len());
+    println!("svg hits {:#?}", svg_hits);
+    println!(
+        "visited: {:#?}",
+        visited
+            .iter()
+            .filter(|v| v.ends_with(".svg"))
+            .collect::<Vec<_>>()
+    );
+    println!("{:#?}", crawl_errors);
 }


### PR DESCRIPTION
currently does track errrors and crawls svg links.
But given the example site and search term no hits are found.
trying with the keyword 'energy' instead of albedo does find hits on the svg links.

Unsure if there are svg links I have not correctly captured.