### PR TITLE
Fix rustlings submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,6 @@
 [submodule "sc-24sp/git-games/game-15"]
 	path = sc-24sp/git-games/game-15
 	url = https://github.com/TheEvergreenStateCollege/game-15
+[submodule "sc-24sp/git-games/rustlings"]
+	path = sc-24sp/git-games/rustlings
+	url = https://github.com/rust-lang/rustlings.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -44,5 +44,5 @@
 	path = sc-24sp/git-games/game-15
 	url = https://github.com/TheEvergreenStateCollege/game-15
 [submodule "sc-24sp/git-games/rustlings"]
-	path = sc-24sp/git-games/rustlings
+	path = sc-24sp/rustlings
 	url = https://github.com/rust-lang/rustlings.git


### PR DESCRIPTION
Please test by opening a gitpod at the branch `prep-week0`

https://gitpod.io/new#https://github.com/TheEvergreenStateCollege/upper-division-cs/tree-prep-week0

and when the workspace is open, running

```
cd sc-24sp
git submodule update --init
```

it should populate `rustlings` and `git-games/game-xx` without errors.